### PR TITLE
More rules

### DIFF
--- a/docs/rules/limit-nested-ternaries.md
+++ b/docs/rules/limit-nested-ternaries.md
@@ -1,0 +1,32 @@
+# Limits the how deeply you can nest ternary expressions (limit-nested-ternaries)
+
+There is a `no-nested-ternary` rule already, but this rule allows configuring the level you want.
+
+## Rule Details
+
+This rule aims to limit ternaries to a certain depth. The default is 2.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const varName = test1 ? true : test2 ? true : test3 ? true : false;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+const varName = test1 ? true : test2 ? false;
+const varName = test1 ? true : false;
+```
+
+### Options
+To disable:
+```
+"limit-nested-ternaries": 0
+```
+
+To change the limit:
+```
+"limit-nested-ternaries": [2, { limit: 3 }]
+```

--- a/docs/rules/no-default-export.md
+++ b/docs/rules/no-default-export.md
@@ -1,0 +1,34 @@
+# Restrict use of default export (no-default-export)
+
+Require named exports. This rule is intended for use in internal projects
+with strong API conventions. It is not recommended for public libraries
+where default exports are beneficial and allow consumers to use without
+knowing the names of internal variables.
+
+## Rule Details
+
+This rule aims to restrict default exports.
+
+Examples of **incorrect** code for this rule:
+
+```js
+export default test = 'test';
+export default function() {};
+export default class Test {};
+export { test as default };
+export { default } from 'test';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+export const test = 'test';
+export class Test {};
+export function test() {};
+export { default as test } from 'test';
+export { test } from 'test';
+```
+
+## When Not To Use It
+
+If you want to use default exports

--- a/docs/rules/required-exports.md
+++ b/docs/rules/required-exports.md
@@ -1,0 +1,68 @@
+# Require specific exported names by file name/path (required-exports)
+
+This rule will allow your team to enforce certain maodule APIs. For example,
+splitting React components up into container.js, ui.js, test.js, etc. and requiring
+that each file has specifically named exports.
+
+## Rule Details
+
+This rule aims to enforce module APIs by filepath.
+
+Examples of **incorrect** code for this rule:
+
+```js
+// src/components/MyComponent/ui.js
+// options: [{ match: '^.*/components/.*/ui.js$', exports: [ ':dir:UI' ] }]
+export class MyComponentContainer {
+    ....
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// src/components/MyComponent/ui.js
+// options: [{ match: '^.*/components/.*/ui.js$', exports: [ ':dir:UI' ] }]
+export class MyComponentUI {
+    ....
+}
+```
+
+### Options
+
+Options should be an array of objects where each object has two keys:
+
+match    - regular expression for the files to check
+exports  - array of the required export names
+            - :dir: will be substituted with the parent directory name
+            - :file: will be substituted with the file name
+            - default can be used to require a default export
+
+```js
+// The following will require an export named "MyComponentUI" when processing
+// "src/components/MyComponent/ui.js"
+"required-exports": [
+    2,
+    [{
+        match: "^.*/components/.*/ui.js$", 
+        exports: [ ':dir:UI' ] 
+    }]
+]
+```
+
+```js
+// The following will require an export named "MyComponent" when processing
+// "src/components/MyComponent.js"
+"required-exports": [
+    2,
+    [{
+        match: "^.*/components/*.js$", 
+        exports: [ ':file:' ] 
+    }]
+]
+```
+
+## When Not To Use It
+
+When you want to enforce some specific conventions around file/directory structure
+and APIs for a set of modules.

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,8 @@ module.exports.configs = {
         rules: {
             'no-nested-ternary': 0,
             'lola/no-arrow-class-properties': 2,
-            'lola/limit-nested-ternaries': 2
+            'lola/limit-nested-ternaries': 2,
+            'lola/no-default-export': 2
         }
     }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,9 @@ module.exports.rules = requireIndex(__dirname + "/rules");
 module.exports.configs = {
     standard: {
         rules: {
-            'lola/no-arrow-class-properties': 2
+            'no-nested-ternary': 0,
+            'lola/no-arrow-class-properties': 2,
+            'lola/limit-nested-ternaries': 2
         }
     }
 };

--- a/lib/rules/limit-nested-ternaries.js
+++ b/lib/rules/limit-nested-ternaries.js
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Limits the how deeply you can nest ternary expressions
+ * @author Kevin LaFlamme
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Limits the how deeply you can nest ternary expressions",
+            category: "Fill me in",
+            recommended: false
+        },
+        fixable: null,  // or "code" or "whitespace"
+        schema: [{
+            type: 'object',
+            properties: {
+                'limit': {
+                    type: 'number'
+                }
+            }
+        }]
+    },
+
+    create: function(context) {
+        var LIMIT = context.options[0] ? context.options[0].limit : 2;
+        var processed = {};
+        return {
+            ConditionalExpression: function(node) {
+                var count = 1;
+                var conditional = node;
+                while (conditional.alternate.type === 'ConditionalExpression') {
+                    count += 1;
+                    conditional = conditional.alternate;
+                }
+
+                if (count > LIMIT) {
+                    context.report(node, "Found ternary " + count + " levels deep, limit is " + LIMIT);
+                }
+            }
+        };
+    }
+};

--- a/lib/rules/no-default-export.js
+++ b/lib/rules/no-default-export.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Restrict use of default export
+ * @author Kevin LaFlamme
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Restrict use of default export",
+            category: "",
+            recommended: false
+        },
+        fixable: null,  // or "code" or "whitespace"
+        schema: []
+    },
+
+    create: function(context) {
+
+        return {
+            ExportNamedDeclaration: function(node) {
+                node.specifiers.forEach(function(specifier) {
+                    if (specifier.exported.name === 'default') {
+                        context.report(node, "Prefer named exports");
+                    }
+                });
+            },
+            ExportDefaultDeclaration: function(node) {
+                context.report(node, "Prefer named exports");
+            }
+        };
+    }
+};

--- a/lib/rules/required-exports.js
+++ b/lib/rules/required-exports.js
@@ -1,0 +1,113 @@
+/**
+ * @fileoverview Require specific exported names by file name/path
+ * @author Kevin LaFlamme
+ */
+"use strict";
+var path = require('path');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Require specific exported names by file name/path",
+            category: "Fill me in",
+            recommended: false
+        },
+        fixable: null,  // or "code" or "whitespace"
+        schema: [{
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    match: {
+                        type: 'string'
+                    },
+                    exports: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    }
+                }
+            }
+        }]
+    },
+
+    create: function(context) {
+
+        var exports;
+        var requiredExports;
+
+        return {
+            "ExportNamedDeclaration": function(node) {
+                if (!requiredExports.size) return;
+
+                node.specifiers.forEach(function(specifier) {
+                    exports.add(specifier.exported.name);
+                });
+
+                if (node.declaration && ['ClassDeclaration', 'FunctionDeclaration'].indexOf(node.declaration.type) !== -1) {
+                    exports.add(node.declaration.id.name);
+                } else if (node.declaration && node.declaration.type === 'VariableDeclaration') {
+                    node.declaration.declarations.forEach(function(decl) {
+                        if (decl.id.type === 'Identifier') {
+                            exports.add(decl.id.name);
+                        } else if (decl.id.type === 'ObjectPattern') {
+                            decl.id.properties.forEach(function(property) {
+                                if (property.value.type === 'Identifier') {
+                                    exports.add(property.value.name);
+                                } else {
+                                    exports.add(property.key.name);
+                                }
+                            });
+                        }
+                    });
+                }
+            },
+
+            "ExportDefaultDeclaration": function(node) {
+                exports.add('default');
+            },
+
+            "Program": function(node) {
+                exports = new Set();
+                requiredExports = new Set();
+                var filePath = context.getFilename();
+                var ext = path.extname(filePath);
+                var file = {
+                    dir: path.basename(path.dirname(filePath)),
+                    name: path.basename(filePath, ext)
+                };
+                var options = context.options[0] || [];
+                
+                options.forEach(function(option) {
+                    var match = new RegExp(option.match);
+                    if (match.test(filePath)) {
+                        option.exports.forEach(function(e) {
+                            return requiredExports.add(e.replace(':dir:', file.dir).replace(':file:', file.name));
+                        });
+                    }
+                });
+            },
+
+            "Program:exit": function(node) {
+                var missing = [];
+                requiredExports.forEach(function(exp) {
+                    if (!exports.has(exp)) {
+                        missing.push(exp);
+                    }
+                });
+
+                if (missing.length) {
+                    var msg = missing.map(function(m) {
+                        return "'" + m + "'";
+                    }).join(', ')
+                    context.report(node, 'Missing required exports: ' + msg);
+                }
+            }
+        };
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-lola",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Enforce Lola javascript conventions",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/limit-nested-ternaries.js
+++ b/tests/lib/rules/limit-nested-ternaries.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Limits the how deeply you can nest ternary expressions
+ * @author Kevin LaFlamme
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/limit-nested-ternaries"),
+
+    RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("limit-nested-ternaries", rule, {
+
+    valid: [{
+            code: "test1 ? true : test2 ? true : test3",
+            options: [{ limit: 3 }]
+        },
+        {
+            code: "test1 ? true : test2 ? true : test3 ? true : false",
+            options: [{ limit: 3 }]
+        }
+    ],
+
+    invalid: [
+        {
+            code: "test1 ? true : test2 ? true : test3 ? true : false",
+            errors: [{
+                message: "Found ternary 3 levels deep, limit is 2",
+                type: "ConditionalExpression"
+            }]
+        }, {
+            code: "test1 ? true : test2 ? true : test3 ? true : test4 ? true : false",
+            options: [{ limit: 3 }],
+            errors: [{
+                message: "Found ternary 4 levels deep, limit is 3",
+                type: "ConditionalExpression"
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/no-arrow-class-properties.js
+++ b/tests/lib/rules/no-arrow-class-properties.js
@@ -38,7 +38,7 @@ ruleTester.run("no-arrow-class-properties", rule, {
                 method = () => 'bad';
             }`,
             errors: [{
-                message: 'Arrow functions are not allowed as class properties: \'method\' in \'Bad\'',
+                message: "Unexpected arrow function 'method' on class 'Bad'",
                 type: 'ClassProperty'
             }]
         }

--- a/tests/lib/rules/no-default-export.js
+++ b/tests/lib/rules/no-default-export.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Restrict use of default export
+ * @author Kevin LaFlamme
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-default-export"),
+
+    RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({ parser: 'babel-eslint' });
+ruleTester.run("no-default-export", rule, {
+
+    valid: [
+        {
+            code: "export class Test {}"
+        },
+        {
+            code: "export function test() {}"
+        },
+         {
+            code: "export const Test = 'test'"
+        }
+    ],
+
+    invalid: [
+        {
+            code: "export default 'test'",
+            errors: [{
+                message: "Prefer named exports",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "export { test as default }",
+            errors: [{
+                message: "Prefer named exports",
+                type: "ExportNamedDeclaration"
+            }]
+        },
+        {
+            code: "export { default } from 'test'",
+            errors: [{
+                message: "Prefer named exports",
+                type: "ExportNamedDeclaration"
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/required-exports.js
+++ b/tests/lib/rules/required-exports.js
@@ -1,0 +1,192 @@
+/**
+ * @fileoverview Require specific exported names by file name/path
+ * @author Kevin LaFlamme
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/required-exports"),
+
+    RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({ parser: 'babel-eslint' });
+ruleTester.run("required-exports", rule, {
+
+    valid: [
+        {
+            code: "export { test };",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'test' ]
+                }]
+            ]
+        },
+        {
+            code: "export { test1, test2 };",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'test1', 'test2' ]
+                }]
+            ]
+        },
+        {
+            code: "export { test1 as test3, test2 as test4 };",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'test3', 'test4' ]
+                }]
+            ]
+        },
+        {
+            code: "export const { test1: test3, test2: test4 } = test5;",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'test3', 'test4' ]
+                }]
+            ]
+        },
+        {
+            code: "export const test = 'test'",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'test' ]
+                }]
+            ]
+        },
+        {
+            code: "export let test = 'test'",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'test' ]
+                }]
+            ]
+        },
+        {
+            code: "export var test = 'test'",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'test' ]
+                }]
+            ]
+        },
+        {
+            code: "export function Test() {}",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'Test' ]
+                }]
+            ]
+        },
+        {
+            code: "export class Test {}",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'Test' ]
+                }]
+            ]
+        },
+        {
+            code: "export default 'test';",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'default' ]
+                }]
+            ]
+        },
+        {
+            code: "export { test as default };",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'default' ]
+                }]
+            ]
+        },
+        {
+            code: "export default function() {};",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'default' ]
+                }]
+            ]
+        },
+        {
+            code: "export default class Test {};",
+            filename: 'test.js',
+            options: [
+                [{
+                    match: '^.*$',
+                    exports: [ 'default' ]
+                }]
+            ]
+        },
+        {
+            code: "export { TestUI };",
+            filename: '/system/project/src/components/Test/ui.js',
+            options: [
+                [{
+                    match: '^.*/components/.*/ui.js$',
+                    exports: [ ':dir:UI' ]
+                }]
+            ]
+        },
+        {
+            code: "export { Test };",
+            filename: '/system/project/src/components/Test.js',
+            options: [
+                [{
+                    match: '^.*/components/.*/ui.js$',
+                    exports: [ ':file:' ]
+                }]
+            ]
+        }
+    ],
+
+    invalid: [
+        {
+            code: "export { Test }",
+            filename: '/system/project/src/components/Test/ui.js',
+            options: [
+                [{
+                    match: '^.*/components/.*/ui.js$',
+                    exports: [ ':dir:UI', ':file:' ]
+                }]
+            ],
+            errors: [{
+                message: "Missing required exports: 'TestUI', 'ui'",
+                type: "Program"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
Add 3 more rules to the plugin:

### `limit-nested-ternaries`
Allows you to set a specific ternary depth limit.

ie. you can allow 
```js
cond1 ? true : cond2 ? true : false
```
but not allow:
```
cond1 ? true : cond2 ? true : cond3 ? true : false
```


### `required-exports`
Allows you to required specific named exports by file path.

Say you want to have all components be done as directories and export the directory name in `index.js`.
```
//  src/components/Button/styles.js
//  src/components/Button/Button.js
//  src/components/Button/index.js .     -> Must export `Button`
"required-exports": [
    "error",
    [{
         "match": "^.*(/components/).*/index.js",
         "exports": [":dir:"]
    }]
]
```

### `no-default-export`
Restrict default exports altogether and required named exports only